### PR TITLE
GloriousEggroll

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -106,6 +106,7 @@ runners_dir="$data_dir/lutris/runners/wine"
 runner_sources=(
     "RawFox" "https://api.github.com/repos/rawfoxDE/raw-wine/releases"
     "Molotov/Snatella" "https://api.github.com/repos/snatella/wine-runner-sc/releases"
+    "GloriousEggroll" "https://api.github.com/repos/GloriousEggroll/wine-ge-custom/releases"
 )
 # Set a maximum number of runner versions to display from each url
 max_runners=20


### PR DESCRIPTION
Add GloriousEggroll's new custom Lutris runner builds. The first build, 6.9, runs Star Citizen, and this is probably a good Lutris runner to have installed for playing games via WINE and Lutris in general.