### PR TITLE
fix locale causing memory preflight check to fail

### DIFF
--- a/lug-helper.sh
+++ b/lug-helper.sh
@@ -665,7 +665,7 @@ filelimit_check() {
 
 # Check total system memory
 memory_check() {
-    memtotal="$(awk '/MemTotal/ {printf "%.1f \n", $2/1024/1024}' /proc/meminfo)"
+    memtotal="$(LC_NUMERIC=C awk '/MemTotal/ {printf "%.1f \n", $2/1024/1024}' /proc/meminfo)"
     if [ ${memtotal%.*} -ge "15" ]; then
         preflight_pass+=("Your system has $memtotal GB of memory.")  
     else


### PR DESCRIPTION
if the locale uses a decimal `,` instead of `.`, the memory preflight check fails.
in my case it displayed:
```
Failed Checks:
- Your system has 31,4  GB of memory.
    We recommend at least 16 GB to avoid crashes.
```


fix provided by @gort818 after i posted the error on the LUG-Discord-Server